### PR TITLE
cat instead of echo for privacy

### DIFF
--- a/_posts/2017-11-10-ssh-add-from-environment-variable.md
+++ b/_posts/2017-11-10-ssh-add-from-environment-variable.md
@@ -16,7 +16,7 @@ To redirect the contents of the environment variable into `ssh-add` instead of a
 
 ```
 eval $(ssh-agent -s) 
-ssh-add <(echo "$PRIVATE_KEY") 
+ssh-add <(cat <<<"$PRIVATE_KEY") 
 
 # List out your new key's fingerprint
 ssh-add -l


### PR DESCRIPTION
Other users on the system could be watching processes
and would see any arguments passed to echo. Using a
here string avoids this.